### PR TITLE
cryptography: add MAYO signature scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,7 +872,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -871,7 +893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -1283,12 +1305,14 @@ dependencies = [
  "num-rational",
  "num-traits",
  "p256 0.13.2",
+ "pq-mayo",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rayon",
  "rstest",
  "sha2 0.10.9",
+ "signature 2.2.0",
  "thiserror 2.0.17",
  "x25519-dalek",
  "zeroize",
@@ -1882,6 +1906,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2076,6 +2109,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2091,7 +2133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -2656,9 +2698,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -2904,6 +2960,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3144,6 +3210,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3178,6 +3250,8 @@ checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3289,10 +3363,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -3869,7 +3958,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3902,6 +3991,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pq-mayo"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df4af2a3a1dac97eed475c38674ccc0dfcd833af2a1308a353bfe4a3d454fc8"
+dependencies = [
+ "aes",
+ "ctr",
+ "hex",
+ "hybrid-array",
+ "rand 0.10.1",
+ "sha3",
+ "signature 2.2.0",
+ "subtle",
+ "thiserror 2.0.17",
+ "zeroize",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -4097,6 +4214,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4115,6 +4238,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4154,6 +4288,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -4245,7 +4385,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cffef0520d30fbd4151fb20e262947ae47fb0ab276a744a19b6398438105a072"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "fixedbitset",
  "once_cell",
  "readme-rustdocifier",
@@ -4737,7 +4877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -4749,7 +4889,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -4761,7 +4901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
  "sha2-asm",
 ]
@@ -4773,6 +4913,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]
@@ -5539,6 +5689,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5671,7 +5827,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -5730,6 +5895,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -6130,6 +6329,94 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ p256 = { version = "0.13.2", default-features = false }
 parking_lot = "0.12.5"
 paste = "1.0.15"
 pin-project = "1.1.10"
+pq-mayo = "0.2.3"
 proc-macro-crate = "3.4.0"
 proc-macro2 = "1.0"
 prometheus-client = "0.24.0"
@@ -157,6 +158,7 @@ serde = "1.0.218"
 serde_json = "1.0.122"
 serde_yaml = "0.9.34"
 sha2 = { version = "0.10.8", default-features = false }
+signature = "2.2.0"
 syn = "2.0.0"
 sysinfo = "0.37.2"
 thiserror = { version = "2.0.12", default-features = false }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -64,6 +64,9 @@ mocks = [
 	"commonware-p2p/mocks",
 	"commonware-resolver/mocks",
 ]
+mayo = [
+	"commonware-cryptography/mayo",
+]
 arbitrary = [
 	"commonware-codec/arbitrary",
 	"commonware-coding/arbitrary",

--- a/consensus/src/simplex/scheme/mayo.rs
+++ b/consensus/src/simplex/scheme/mayo.rs
@@ -1,0 +1,10 @@
+//! MAYO implementation of the [`Scheme`] trait for `simplex`.
+//!
+//! [`Scheme`] is attributable: individual signatures can be presented as
+//! evidence of validator activity or faults. Certificates contain signer
+//! indices alongside individual MAYO signatures.
+
+use crate::simplex::{scheme::Namespace, types::Subject};
+use commonware_cryptography::impl_certificate_mayo;
+
+impl_certificate_mayo!(Subject<'a, D>, Namespace);

--- a/consensus/src/simplex/scheme/mod.rs
+++ b/consensus/src/simplex/scheme/mod.rs
@@ -47,6 +47,8 @@ use commonware_utils::union;
 pub mod bls12381_multisig;
 pub mod bls12381_threshold;
 pub mod ed25519;
+#[cfg(feature = "mayo")]
+pub mod mayo;
 commonware_macros::stability_mod!(ALPHA, pub mod secp256r1);
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -32,10 +32,12 @@ ed25519-consensus = { workspace = true, default-features = false }
 num-rational = { workspace = true, optional = true }
 num-traits = { workspace = true, optional = true }
 p256 = { workspace = true, features = ["ecdsa"] }
+pq-mayo = { workspace = true, optional = true }
 rand.workspace = true
 rand_chacha.workspace = true
 rand_core.workspace = true
 sha2.workspace = true
+signature = { workspace = true, optional = true }
 thiserror.workspace = true
 x25519-dalek = { workspace = true, features = ["zeroize"] }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
@@ -73,6 +75,11 @@ default = [ "std" ]
 blake3-parallel = [ "blake3/rayon", "std" ]
 sha2-asm = [ "sha2/asm" ]
 mocks = [ "std" ]
+mayo = [
+	"dep:pq-mayo",
+	"dep:signature",
+	"std",
+]
 arbitrary = [
 	"commonware-codec/arbitrary",
 	"commonware-math/arbitrary",

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -45,6 +45,9 @@ commonware_macros::stability_scope!(ALPHA {
     pub mod lthash;
     pub use crate::lthash::LtHash;
 });
+commonware_macros::stability_scope!(ALPHA, cfg(feature = "mayo") {
+    pub mod mayo;
+});
 commonware_macros::stability_scope!(BETA {
     use commonware_codec::{Encode, ReadExt};
     use commonware_math::algebra::Random;

--- a/cryptography/src/mayo/certificate/mod.rs
+++ b/cryptography/src/mayo/certificate/mod.rs
@@ -1,0 +1,540 @@
+//! MAYO signing scheme implementation.
+
+use super::{Mayo1, MayoParameter, PrivateKey, PublicKey, Signature as MayoSignature};
+use crate::{
+    certificate::{Attestation, Namespace, Scheme, Signers, Subject},
+    Digest, Signer as _, Verifier as _,
+};
+use bytes::{Buf, BufMut};
+use commonware_codec::{types::lazy::Lazy, EncodeSize, Error, Read, ReadRangeExt, Write};
+use commonware_utils::{
+    ordered::{Quorum, Set},
+    Faults, Participant,
+};
+
+/// Generic MAYO signing scheme implementation.
+#[derive(Clone, Debug)]
+pub struct Generic<P: MayoParameter, N: Namespace> {
+    /// Participants in the committee.
+    pub participants: Set<PublicKey<P>>,
+    /// Key used for generating signatures.
+    pub signer: Option<(Participant, PrivateKey<P>)>,
+    /// Pre-computed namespace(s) for this subject type.
+    pub namespace: N,
+}
+
+impl<P: MayoParameter, N: Namespace> Generic<P, N> {
+    /// Creates a new generic MAYO scheme instance.
+    pub fn signer(
+        namespace: &[u8],
+        participants: Set<PublicKey<P>>,
+        private_key: PrivateKey<P>,
+    ) -> Option<Self> {
+        let signer = participants
+            .index(&private_key.public_key())
+            .map(|index| (index, private_key))?;
+
+        Some(Self {
+            participants,
+            signer: Some(signer),
+            namespace: N::derive(namespace),
+        })
+    }
+
+    /// Builds a verifier that can authenticate signatures without generating them.
+    pub fn verifier(namespace: &[u8], participants: Set<PublicKey<P>>) -> Self {
+        Self {
+            participants,
+            signer: None,
+            namespace: N::derive(namespace),
+        }
+    }
+
+    /// Returns the index of "self" in the participant set, if available.
+    pub fn me(&self) -> Option<Participant> {
+        self.signer.as_ref().map(|(index, _)| *index)
+    }
+
+    /// Signs a subject and returns the signer index and signature.
+    pub fn sign<'a, S, D>(&self, subject: S::Subject<'a, D>) -> Option<Attestation<S>>
+    where
+        S: Scheme<Signature = MayoSignature<P>>,
+        S::Subject<'a, D>: Subject<Namespace = N>,
+        D: Digest,
+    {
+        let (index, private_key) = self.signer.as_ref()?;
+        let signature = private_key.sign(subject.namespace(&self.namespace), &subject.message());
+
+        Some(Attestation {
+            signer: *index,
+            signature: signature.into(),
+        })
+    }
+
+    /// Verifies a single attestation from a signer.
+    pub fn verify_attestation<'a, S, D>(
+        &self,
+        subject: S::Subject<'a, D>,
+        attestation: &Attestation<S>,
+    ) -> bool
+    where
+        S: Scheme<Signature = MayoSignature<P>>,
+        S::Subject<'a, D>: Subject<Namespace = N>,
+        D: Digest,
+    {
+        let Some(public_key) = self.participants.key(attestation.signer) else {
+            return false;
+        };
+        let Some(signature) = attestation.signature.get() else {
+            return false;
+        };
+
+        public_key.verify(
+            subject.namespace(&self.namespace),
+            &subject.message(),
+            signature,
+        )
+    }
+
+    /// Assembles a certificate from a collection of attestations.
+    pub fn assemble<S, I, M>(&self, attestations: I) -> Option<Certificate<P>>
+    where
+        S: Scheme<Signature = MayoSignature<P>>,
+        I: IntoIterator<Item = Attestation<S>>,
+        M: Faults,
+    {
+        let mut entries = Vec::new();
+        for Attestation { signer, signature } in attestations {
+            if usize::from(signer) >= self.participants.len() {
+                return None;
+            }
+            let signature = signature.get().cloned()?;
+            entries.push((signer, signature));
+        }
+        if entries.len() < self.participants.quorum::<M>() as usize {
+            return None;
+        }
+
+        entries.sort_by_key(|(signer, _)| *signer);
+        let (signer, signatures): (Vec<Participant>, Vec<_>) = entries.into_iter().unzip();
+        let signers = Signers::from(self.participants.len(), signer);
+        let signatures = signatures.into_iter().map(Lazy::from).collect();
+
+        Some(Certificate {
+            signers,
+            signatures,
+        })
+    }
+
+    /// Verifies a certificate by checking each signature individually.
+    pub fn verify_certificate<'a, S, D, M>(
+        &self,
+        subject: S::Subject<'a, D>,
+        certificate: &Certificate<P>,
+    ) -> bool
+    where
+        S: Scheme<Signature = MayoSignature<P>>,
+        S::Subject<'a, D>: Subject<Namespace = N>,
+        D: Digest,
+        M: Faults,
+    {
+        if certificate.signers.len() != self.participants.len() {
+            return false;
+        }
+        if certificate.signers.count() != certificate.signatures.len() {
+            return false;
+        }
+        if certificate.signers.count() < self.participants.quorum::<M>() as usize {
+            return false;
+        }
+
+        let namespace = subject.namespace(&self.namespace);
+        let message = subject.message();
+        for (signer, signature) in certificate.signers.iter().zip(&certificate.signatures) {
+            let Some(public_key) = self.participants.key(signer) else {
+                return false;
+            };
+            let Some(signature) = signature.get() else {
+                return false;
+            };
+            if !public_key.verify(namespace, &message, signature) {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    pub const fn is_attributable() -> bool {
+        true
+    }
+
+    pub const fn is_batchable() -> bool {
+        false
+    }
+
+    pub const fn certificate_codec_config(&self) -> <Certificate<P> as Read>::Cfg {
+        self.participants.len()
+    }
+
+    pub const fn certificate_codec_config_unbounded() -> <Certificate<P> as Read>::Cfg {
+        u32::MAX as usize
+    }
+}
+
+pub struct Certificate<P: MayoParameter = Mayo1> {
+    /// Bitmap of participant indices that contributed signatures.
+    pub signers: Signers,
+    /// MAYO signatures emitted by the respective participants ordered by signer index.
+    pub signatures: Vec<Lazy<MayoSignature<P>>>,
+}
+
+impl<P: MayoParameter> Clone for Certificate<P> {
+    fn clone(&self) -> Self {
+        Self {
+            signers: self.signers.clone(),
+            signatures: self.signatures.clone(),
+        }
+    }
+}
+
+impl<P: MayoParameter> core::fmt::Debug for Certificate<P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Certificate")
+            .field("signers", &self.signers)
+            .field("signatures", &self.signatures)
+            .finish()
+    }
+}
+
+impl<P: MayoParameter> PartialEq for Certificate<P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.signers == other.signers && self.signatures == other.signatures
+    }
+}
+
+impl<P: MayoParameter> Eq for Certificate<P> {}
+
+impl<P: MayoParameter> core::hash::Hash for Certificate<P> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.signers.hash(state);
+        self.signatures.hash(state);
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<P: MayoParameter> arbitrary::Arbitrary<'_> for Certificate<P> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        let signers = Signers::arbitrary(u)?;
+        let signatures = (0..signers.count())
+            .map(|_| u.arbitrary::<MayoSignature<P>>().map(Lazy::from))
+            .collect::<arbitrary::Result<Vec<_>>>()?;
+        Ok(Self {
+            signers,
+            signatures,
+        })
+    }
+}
+
+impl<P: MayoParameter> Write for Certificate<P> {
+    fn write(&self, writer: &mut impl BufMut) {
+        self.signers.write(writer);
+        self.signatures.write(writer);
+    }
+}
+
+impl<P: MayoParameter> EncodeSize for Certificate<P> {
+    fn encode_size(&self) -> usize {
+        self.signers.encode_size() + self.signatures.encode_size()
+    }
+}
+
+impl<P: MayoParameter> Read for Certificate<P> {
+    type Cfg = usize;
+
+    fn read_cfg(reader: &mut impl Buf, participants: &usize) -> Result<Self, Error> {
+        let signers = Signers::read_cfg(reader, participants)?;
+        if signers.count() == 0 {
+            return Err(Error::Invalid(
+                "cryptography::mayo::certificate::Certificate",
+                "Certificate contains no signers",
+            ));
+        }
+
+        let signatures = Vec::<Lazy<MayoSignature<P>>>::read_range(reader, ..=*participants)?;
+        if signers.count() != signatures.len() {
+            return Err(Error::Invalid(
+                "cryptography::mayo::certificate::Certificate",
+                "Signers and signatures counts differ",
+            ));
+        }
+
+        Ok(Self {
+            signers,
+            signatures,
+        })
+    }
+}
+
+/// Generates a MAYO signing scheme wrapper for a specific protocol.
+#[macro_export]
+macro_rules! impl_certificate_mayo {
+    ($subject:ty, $namespace:ty) => {
+        /// MAYO signing scheme wrapper.
+        pub struct Scheme<P: $crate::mayo::MayoParameter = $crate::mayo::Mayo1> {
+            generic: $crate::mayo::certificate::Generic<P, $namespace>,
+        }
+
+        impl<P: $crate::mayo::MayoParameter> Clone for Scheme<P> {
+            fn clone(&self) -> Self {
+                Self {
+                    generic: self.generic.clone(),
+                }
+            }
+        }
+
+        impl<P: $crate::mayo::MayoParameter> core::fmt::Debug for Scheme<P> {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.debug_struct("Scheme").finish_non_exhaustive()
+            }
+        }
+
+        impl<P: $crate::mayo::MayoParameter> Scheme<P> {
+            /// Creates a new scheme instance with the provided key material.
+            pub fn signer(
+                namespace: &[u8],
+                participants: commonware_utils::ordered::Set<$crate::mayo::PublicKey<P>>,
+                private_key: $crate::mayo::PrivateKey<P>,
+            ) -> Option<Self> {
+                Some(Self {
+                    generic: $crate::mayo::certificate::Generic::signer(
+                        namespace,
+                        participants,
+                        private_key,
+                    )?,
+                })
+            }
+
+            /// Builds a verifier that can authenticate signatures without generating them.
+            pub fn verifier(
+                namespace: &[u8],
+                participants: commonware_utils::ordered::Set<$crate::mayo::PublicKey<P>>,
+            ) -> Self {
+                Self {
+                    generic: $crate::mayo::certificate::Generic::verifier(
+                        namespace,
+                        participants,
+                    ),
+                }
+            }
+        }
+
+        impl<P: $crate::mayo::MayoParameter> $crate::certificate::Scheme for Scheme<P> {
+            type Subject<'a, D: $crate::Digest> = $subject;
+            type PublicKey = $crate::mayo::PublicKey<P>;
+            type Signature = $crate::mayo::Signature<P>;
+            type Certificate = $crate::mayo::certificate::Certificate<P>;
+
+            fn me(&self) -> Option<commonware_utils::Participant> {
+                self.generic.me()
+            }
+
+            fn participants(&self) -> &commonware_utils::ordered::Set<Self::PublicKey> {
+                &self.generic.participants
+            }
+
+            fn sign<D: $crate::Digest>(
+                &self,
+                subject: Self::Subject<'_, D>,
+            ) -> Option<$crate::certificate::Attestation<Self>> {
+                self.generic.sign::<Self, D>(subject)
+            }
+
+            fn verify_attestation<R, D>(
+                &self,
+                _rng: &mut R,
+                subject: Self::Subject<'_, D>,
+                attestation: &$crate::certificate::Attestation<Self>,
+                _strategy: &impl commonware_parallel::Strategy,
+            ) -> bool
+            where
+                R: rand_core::CryptoRngCore,
+                D: $crate::Digest,
+            {
+                self.generic
+                    .verify_attestation::<Self, D>(subject, attestation)
+            }
+
+            fn assemble<I, M>(
+                &self,
+                attestations: I,
+                _strategy: &impl commonware_parallel::Strategy,
+            ) -> Option<Self::Certificate>
+            where
+                I: IntoIterator<Item = $crate::certificate::Attestation<Self>>,
+                M: commonware_utils::Faults,
+            {
+                self.generic.assemble::<Self, _, M>(attestations)
+            }
+
+            fn verify_certificate<R, D, M>(
+                &self,
+                _rng: &mut R,
+                subject: Self::Subject<'_, D>,
+                certificate: &Self::Certificate,
+                _strategy: &impl commonware_parallel::Strategy,
+            ) -> bool
+            where
+                R: rand_core::CryptoRngCore,
+                D: $crate::Digest,
+                M: commonware_utils::Faults,
+            {
+                self.generic
+                    .verify_certificate::<Self, D, M>(subject, certificate)
+            }
+
+            fn is_attributable() -> bool {
+                $crate::mayo::certificate::Generic::<P, $namespace>::is_attributable()
+            }
+
+            fn is_batchable() -> bool {
+                $crate::mayo::certificate::Generic::<P, $namespace>::is_batchable()
+            }
+
+            fn certificate_codec_config(
+                &self,
+            ) -> <Self::Certificate as commonware_codec::Read>::Cfg {
+                self.generic.certificate_codec_config()
+            }
+
+            fn certificate_codec_config_unbounded(
+            ) -> <Self::Certificate as commonware_codec::Read>::Cfg {
+                $crate::mayo::certificate::Generic::<P, $namespace>::certificate_codec_config_unbounded()
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{certificate::Scheme as _, sha256::Digest as Sha256Digest};
+    use bytes::Bytes;
+    use commonware_codec::{Decode, Encode};
+    use commonware_math::algebra::Random;
+    use commonware_parallel::Sequential;
+    use commonware_utils::{ordered::Set, test_rng, Faults, N3f1, TryCollect};
+    use rand_core::CryptoRngCore;
+
+    const NAMESPACE: &[u8] = b"test-mayo";
+    const MESSAGE: &[u8] = b"test message";
+
+    #[derive(Clone, Debug)]
+    pub struct TestSubject {
+        pub message: Bytes,
+    }
+
+    impl Subject for TestSubject {
+        type Namespace = Vec<u8>;
+
+        fn namespace<'a>(&self, derived: &'a Self::Namespace) -> &'a [u8] {
+            derived.as_ref()
+        }
+
+        fn message(&self) -> Bytes {
+            self.message.clone()
+        }
+    }
+
+    impl_certificate_mayo!(TestSubject, Vec<u8>);
+
+    fn setup_signers<P: MayoParameter>(
+        rng: &mut impl CryptoRngCore,
+        n: u32,
+    ) -> (Vec<Scheme<P>>, Scheme<P>) {
+        let private_keys: Vec<_> = (0..n)
+            .map(|_| PrivateKey::<P>::random(&mut *rng))
+            .collect();
+        let participants: Set<PublicKey<P>> = private_keys
+            .iter()
+            .map(|sk| sk.public_key())
+            .try_collect()
+            .unwrap();
+
+        let signers = private_keys
+            .into_iter()
+            .map(|sk| Scheme::signer(NAMESPACE, participants.clone(), sk).unwrap())
+            .collect();
+
+        let verifier = Scheme::verifier(NAMESPACE, participants);
+
+        (signers, verifier)
+    }
+
+    #[test]
+    fn test_is_attributable() {
+        assert!(Generic::<Mayo1, Vec<u8>>::is_attributable());
+        assert!(Scheme::<Mayo1>::is_attributable());
+    }
+
+    #[test]
+    fn test_is_not_batchable() {
+        assert!(!Generic::<Mayo1, Vec<u8>>::is_batchable());
+        assert!(!Scheme::<Mayo1>::is_batchable());
+    }
+
+    #[test]
+    fn test_sign_vote_roundtrip() {
+        let mut rng = test_rng();
+        let (schemes, _) = setup_signers::<Mayo1>(&mut rng, 4);
+        let scheme = &schemes[0];
+
+        let attestation = scheme
+            .sign::<Sha256Digest>(TestSubject {
+                message: Bytes::from_static(MESSAGE),
+            })
+            .unwrap();
+        assert!(scheme.verify_attestation::<_, Sha256Digest>(
+            &mut rng,
+            TestSubject {
+                message: Bytes::from_static(MESSAGE),
+            },
+            &attestation,
+            &Sequential,
+        ));
+    }
+
+    #[test]
+    fn test_certificate_roundtrip() {
+        let mut rng = test_rng();
+        let (schemes, verifier) = setup_signers::<Mayo1>(&mut rng, 4);
+        let quorum = N3f1::quorum(schemes.len()) as usize;
+
+        let subject = TestSubject {
+            message: Bytes::from_static(MESSAGE),
+        };
+        let attestations: Vec<_> = schemes
+            .iter()
+            .take(quorum)
+            .map(|s| s.sign::<Sha256Digest>(subject.clone()).unwrap())
+            .collect();
+
+        let certificate = verifier
+            .assemble::<_, N3f1>(attestations, &Sequential)
+            .unwrap();
+        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+            &mut rng,
+            subject.clone(),
+            &certificate,
+            &Sequential,
+        ));
+
+        let encoded = certificate.encode();
+        let decoded = Certificate::<Mayo1>::decode_cfg(
+            encoded,
+            &verifier.certificate_codec_config(),
+        )
+        .unwrap();
+        assert_eq!(certificate, decoded);
+    }
+}

--- a/cryptography/src/mayo/mod.rs
+++ b/cryptography/src/mayo/mod.rs
@@ -1,0 +1,25 @@
+//! MAYO implementation of the [crate::Verifier] and [crate::Signer] traits.
+//!
+//! MAYO is a post-quantum multivariate signature scheme in the NIST additional
+//! signatures process. This module wraps the `pq-mayo` implementation behind
+//! Commonware's signing and certificate traits.
+//!
+//! # Example
+//! ```rust
+//! use commonware_cryptography::{mayo, PrivateKey, PublicKey, Verifier as _, Signer as _};
+//! use commonware_math::algebra::Random;
+//! use rand::rngs::OsRng;
+//!
+//! let signer = mayo::PrivateKey::<mayo::Mayo1>::random(&mut OsRng);
+//! let namespace = b"demo";
+//! let msg = b"hello, world!";
+//! let signature = signer.sign(namespace, msg);
+//!
+//! assert!(signer.public_key().verify(namespace, msg, &signature));
+//! ```
+
+pub mod certificate;
+mod scheme;
+
+pub use pq_mayo::{Mayo1, Mayo2, Mayo3, Mayo5, MayoParameter};
+pub use scheme::{PrivateKey, PublicKey, Signature};

--- a/cryptography/src/mayo/scheme.rs
+++ b/cryptography/src/mayo/scheme.rs
@@ -1,0 +1,425 @@
+use bytes::{Buf, BufMut};
+use commonware_codec::{util::at_least, Error as CodecError, FixedSize, Read, Write};
+use commonware_math::algebra::Random;
+use commonware_utils::{hex, union_unique, Array, Span};
+use core::{
+    cmp::Ordering,
+    fmt::{Debug, Display},
+    hash::{Hash, Hasher},
+    marker::PhantomData,
+    ops::Deref,
+};
+use pq_mayo::{Mayo1, MayoParameter};
+use rand_core::CryptoRngCore;
+
+const SCHEME_NAME: &str = "mayo";
+
+/// MAYO private key.
+///
+/// The `pq-mayo` crate stores compact signing keys as seeds and zeroizes them on drop.
+pub struct PrivateKey<P: MayoParameter = Mayo1> {
+    key: pq_mayo::SigningKey<P>,
+}
+
+impl<P: MayoParameter> Clone for PrivateKey<P> {
+    fn clone(&self) -> Self {
+        Self {
+            key: self.key.clone(),
+        }
+    }
+}
+
+impl<P: MayoParameter> Debug for PrivateKey<P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrivateKey")
+            .field("variant", &P::NAME)
+            .field("bytes", &"**FILTERED**")
+            .finish_non_exhaustive()
+    }
+}
+
+impl<P: MayoParameter> Display for PrivateKey<P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl<P: MayoParameter> PartialEq for PrivateKey<P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.key.as_ref() == other.key.as_ref()
+    }
+}
+
+impl<P: MayoParameter> Eq for PrivateKey<P> {}
+
+impl<P: MayoParameter> crate::PrivateKey for PrivateKey<P> {}
+
+impl<P: MayoParameter> crate::Signer for PrivateKey<P> {
+    type Signature = Signature<P>;
+    type PublicKey = PublicKey<P>;
+
+    fn public_key(&self) -> Self::PublicKey {
+        PublicKey::from(pq_mayo::VerifyingKey::from(&self.key))
+    }
+
+    fn sign(&self, namespace: &[u8], msg: &[u8]) -> Self::Signature {
+        let payload = union_unique(namespace, msg);
+        let signature =
+            signature::Signer::<pq_mayo::Signature<P>>::try_sign(&self.key, &payload)
+                .expect("MAYO signing failed");
+        Signature::from(signature)
+    }
+}
+
+impl<P: MayoParameter> Random for PrivateKey<P> {
+    fn random(mut rng: impl CryptoRngCore) -> Self {
+        let mut seed = vec![0u8; P::SK_SEED_BYTES];
+        rng.fill_bytes(&mut seed);
+        let keypair =
+            pq_mayo::KeyPair::<P>::from_seed(&seed).expect("seed length matches parameter set");
+        Self {
+            key: keypair.signing_key().clone(),
+        }
+    }
+}
+
+impl<P: MayoParameter> Write for PrivateKey<P> {
+    fn write(&self, buf: &mut impl BufMut) {
+        buf.put_slice(self.key.as_ref());
+    }
+}
+
+impl<P: MayoParameter> Read for PrivateKey<P> {
+    type Cfg = ();
+
+    fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
+        at_least(buf, P::CSK_BYTES)?;
+        let raw = buf.copy_to_bytes(P::CSK_BYTES);
+        let key = pq_mayo::SigningKey::<P>::try_from(raw.as_ref())
+            .map_err(|e| CodecError::Wrapped(SCHEME_NAME, e.into()))?;
+        Ok(Self { key })
+    }
+}
+
+impl<P: MayoParameter> FixedSize for PrivateKey<P> {
+    const SIZE: usize = P::CSK_BYTES;
+}
+
+#[cfg(feature = "arbitrary")]
+impl<P: MayoParameter> arbitrary::Arbitrary<'_> for PrivateKey<P> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        use rand::{rngs::StdRng, SeedableRng};
+
+        let mut rand = StdRng::from_seed(u.arbitrary::<[u8; 32]>()?);
+        Ok(Self::random(&mut rand))
+    }
+}
+
+/// MAYO public key.
+pub struct PublicKey<P: MayoParameter = Mayo1> {
+    raw: Vec<u8>,
+    key: pq_mayo::VerifyingKey<P>,
+}
+
+impl<P: MayoParameter> Clone for PublicKey<P> {
+    fn clone(&self) -> Self {
+        Self {
+            raw: self.raw.clone(),
+            key: self.key.clone(),
+        }
+    }
+}
+
+impl<P: MayoParameter> PartialEq for PublicKey<P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.raw == other.raw
+    }
+}
+
+impl<P: MayoParameter> Eq for PublicKey<P> {}
+
+impl<P: MayoParameter> Hash for PublicKey<P> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.raw.hash(state);
+    }
+}
+
+impl<P: MayoParameter> Ord for PublicKey<P> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.raw.cmp(&other.raw)
+    }
+}
+
+impl<P: MayoParameter> PartialOrd for PublicKey<P> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<P: MayoParameter> crate::PublicKey for PublicKey<P> {}
+
+impl<P: MayoParameter> crate::Verifier for PublicKey<P> {
+    type Signature = Signature<P>;
+
+    fn verify(&self, namespace: &[u8], msg: &[u8], sig: &Self::Signature) -> bool {
+        let payload = union_unique(namespace, msg);
+        signature::Verifier::<pq_mayo::Signature<P>>::verify(&self.key, &payload, &sig.signature)
+            .is_ok()
+    }
+}
+
+impl<P: MayoParameter> Write for PublicKey<P> {
+    fn write(&self, buf: &mut impl BufMut) {
+        buf.put_slice(&self.raw);
+    }
+}
+
+impl<P: MayoParameter> Read for PublicKey<P> {
+    type Cfg = ();
+
+    fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
+        at_least(buf, P::CPK_BYTES)?;
+        let raw = buf.copy_to_bytes(P::CPK_BYTES);
+        pq_mayo::VerifyingKey::<P>::try_from(raw.as_ref())
+            .map(Self::from)
+            .map_err(|e| CodecError::Wrapped(SCHEME_NAME, e.into()))
+    }
+}
+
+impl<P: MayoParameter> FixedSize for PublicKey<P> {
+    const SIZE: usize = P::CPK_BYTES;
+}
+
+impl<P: MayoParameter> Span for PublicKey<P> {}
+
+impl<P: MayoParameter> Array for PublicKey<P> {}
+
+impl<P: MayoParameter> AsRef<[u8]> for PublicKey<P> {
+    fn as_ref(&self) -> &[u8] {
+        &self.raw
+    }
+}
+
+impl<P: MayoParameter> Deref for PublicKey<P> {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.raw
+    }
+}
+
+impl<P: MayoParameter> From<PrivateKey<P>> for PublicKey<P> {
+    fn from(value: PrivateKey<P>) -> Self {
+        <PrivateKey<P> as crate::Signer>::public_key(&value)
+    }
+}
+
+impl<P: MayoParameter> From<pq_mayo::VerifyingKey<P>> for PublicKey<P> {
+    fn from(key: pq_mayo::VerifyingKey<P>) -> Self {
+        Self {
+            raw: key.as_ref().to_vec(),
+            key,
+        }
+    }
+}
+
+impl<P: MayoParameter> Debug for PublicKey<P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", hex(&self.raw))
+    }
+}
+
+impl<P: MayoParameter> Display for PublicKey<P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", hex(&self.raw))
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<P: MayoParameter> arbitrary::Arbitrary<'_> for PublicKey<P> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        use crate::Signer as _;
+        let private_key = u.arbitrary::<PrivateKey<P>>()?;
+        Ok(private_key.public_key())
+    }
+}
+
+/// MAYO signature.
+pub struct Signature<P: MayoParameter = Mayo1> {
+    raw: Vec<u8>,
+    signature: pq_mayo::Signature<P>,
+    _marker: PhantomData<P>,
+}
+
+impl<P: MayoParameter> Clone for Signature<P> {
+    fn clone(&self) -> Self {
+        Self {
+            raw: self.raw.clone(),
+            signature: self.signature.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<P: MayoParameter> PartialEq for Signature<P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.raw == other.raw
+    }
+}
+
+impl<P: MayoParameter> Eq for Signature<P> {}
+
+impl<P: MayoParameter> Hash for Signature<P> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.raw.hash(state);
+    }
+}
+
+impl<P: MayoParameter> Ord for Signature<P> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.raw.cmp(&other.raw)
+    }
+}
+
+impl<P: MayoParameter> PartialOrd for Signature<P> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<P: MayoParameter> crate::Signature for Signature<P> {}
+
+impl<P: MayoParameter> Write for Signature<P> {
+    fn write(&self, buf: &mut impl BufMut) {
+        buf.put_slice(&self.raw);
+    }
+}
+
+impl<P: MayoParameter> Read for Signature<P> {
+    type Cfg = ();
+
+    fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
+        at_least(buf, P::SIG_BYTES)?;
+        let raw = buf.copy_to_bytes(P::SIG_BYTES);
+        pq_mayo::Signature::<P>::try_from(raw.as_ref())
+            .map(Self::from)
+            .map_err(|e| CodecError::Wrapped(SCHEME_NAME, e.into()))
+    }
+}
+
+impl<P: MayoParameter> FixedSize for Signature<P> {
+    const SIZE: usize = P::SIG_BYTES;
+}
+
+impl<P: MayoParameter> Span for Signature<P> {}
+
+impl<P: MayoParameter> Array for Signature<P> {}
+
+impl<P: MayoParameter> AsRef<[u8]> for Signature<P> {
+    fn as_ref(&self) -> &[u8] {
+        &self.raw
+    }
+}
+
+impl<P: MayoParameter> Deref for Signature<P> {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.raw
+    }
+}
+
+impl<P: MayoParameter> From<pq_mayo::Signature<P>> for Signature<P> {
+    fn from(signature: pq_mayo::Signature<P>) -> Self {
+        Self {
+            raw: signature.as_ref().to_vec(),
+            signature,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<P: MayoParameter> Debug for Signature<P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", hex(&self.raw))
+    }
+}
+
+impl<P: MayoParameter> Display for Signature<P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", hex(&self.raw))
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<P: MayoParameter> arbitrary::Arbitrary<'_> for Signature<P> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        use crate::Signer as _;
+        let private_key = u.arbitrary::<PrivateKey<P>>()?;
+        let len = u.arbitrary::<usize>()? % 256;
+        let message = u
+            .arbitrary_iter()?
+            .take(len)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(private_key.sign(&[], &message))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Signer as _, Verifier as _};
+    use commonware_codec::{DecodeExt, Encode};
+    use commonware_utils::test_rng;
+
+    fn sign_and_verify<P: MayoParameter>() {
+        let signer = PrivateKey::<P>::random(&mut test_rng());
+        let public_key = signer.public_key();
+        let signature = signer.sign(b"test-mayo", b"hello mayo");
+
+        assert!(public_key.verify(b"test-mayo", b"hello mayo", &signature));
+        assert!(!public_key.verify(b"test-mayo", b"wrong message", &signature));
+        assert!(!public_key.verify(b"wrong namespace", b"hello mayo", &signature));
+    }
+
+    fn codec_roundtrip<P: MayoParameter>() {
+        let signer = PrivateKey::<P>::random(&mut test_rng());
+        let public_key = signer.public_key();
+        let signature = signer.sign(b"test-mayo", b"hello mayo");
+
+        let signer_decoded = PrivateKey::<P>::decode(signer.encode()).unwrap();
+        let public_key_decoded = PublicKey::<P>::decode(public_key.encode()).unwrap();
+        let signature_decoded = Signature::<P>::decode(signature.encode()).unwrap();
+
+        assert_eq!(signer, signer_decoded);
+        assert_eq!(public_key, public_key_decoded);
+        assert_eq!(signature, signature_decoded);
+        assert!(public_key_decoded.verify(b"test-mayo", b"hello mayo", &signature_decoded));
+    }
+
+    #[test]
+    fn mayo1_sign_and_verify() {
+        sign_and_verify::<pq_mayo::Mayo1>();
+    }
+
+    #[test]
+    fn mayo2_sign_and_verify() {
+        sign_and_verify::<pq_mayo::Mayo2>();
+    }
+
+    #[test]
+    fn mayo3_sign_and_verify() {
+        sign_and_verify::<pq_mayo::Mayo3>();
+    }
+
+    #[test]
+    fn mayo5_sign_and_verify() {
+        sign_and_verify::<pq_mayo::Mayo5>();
+    }
+
+    #[test]
+    fn mayo1_codec_roundtrip() {
+        codec_roundtrip::<pq_mayo::Mayo1>();
+    }
+}


### PR DESCRIPTION
## Summary
- add a feature-gated `mayo` module to `commonware-cryptography` backed by `pq-mayo`
- expose MAYO1, MAYO2, MAYO3, and MAYO5 through Commonware `PrivateKey`, `PublicKey`, `Signature`, `Signer`, and `Verifier` traits
- add an attributable certificate adapter via `impl_certificate_mayo!`
- add a Simplex `mayo` scheme adapter behind a matching `consensus/mayo` feature

## Notes
- this is normal single-party MAYO, not threshold MAYO
- MAYO is gated behind `mayo` because the upstream implementation is `std`-based
- MAYO certificates contain individual signatures, so they are attributable but not compact threshold certificates

## Verification
- `cargo test -p commonware-cryptography --features mayo mayo --lib`
- `cargo test -p commonware-consensus --features mayo simplex::scheme::mayo --lib`